### PR TITLE
Add Populate node

### DIFF
--- a/demo/hoodie_examples/spawn_nodes/area_trigger.tscn
+++ b/demo/hoodie_examples/spawn_nodes/area_trigger.tscn
@@ -1,0 +1,13 @@
+[gd_scene load_steps=3 format=3 uid="uid://cw31liqwpp1mj"]
+
+[ext_resource type="Script" path="res://hoodie_examples/spawn_nodes/collision_shape_3d_test.gd" id="1_y5i8d"]
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_5jr81"]
+
+[node name="AreaTrigger" type="Node3D"]
+
+[node name="Area3D" type="Area3D" parent="."]
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Area3D"]
+shape = SubResource("BoxShape3D_5jr81")
+script = ExtResource("1_y5i8d")

--- a/demo/hoodie_examples/spawn_nodes/collision_shape_3d_test.gd
+++ b/demo/hoodie_examples/spawn_nodes/collision_shape_3d_test.gd
@@ -1,0 +1,13 @@
+@tool
+extends CollisionShape3D
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	print("Hello I'm AreaTrigger")	
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	pass

--- a/demo/hoodie_examples/spawn_nodes/spawn_nodes.tscn
+++ b/demo/hoodie_examples/spawn_nodes/spawn_nodes.tscn
@@ -1,0 +1,119 @@
+[gd_scene load_steps=12 format=3 uid="uid://c524hdfdh6yx0"]
+
+[ext_resource type="PackedScene" uid="uid://cw31liqwpp1mj" path="res://hoodie_examples/spawn_nodes/area_trigger.tscn" id="1_3e6xf"]
+
+[sub_resource type="Curve3D" id="Curve3D_us8u6"]
+bake_interval = 2.0
+_data = {
+"points": PackedVector3Array(-0.604791, 0, 2.14701, 0.604791, 0, -2.14701, -5.28184, 0, 0.604791, -2.04621, 0, 0.070559, 2.04621, 0, -0.070559, -1.81437, 0, -4.78793, -0.846706, 0, -1.62286, 0.846706, 0, 1.62286, 3.11467, 0, -1.85469, 0.493913, 0, -1.59262, -0.493913, 0, 1.59262, 3.9009, 0, 3.49771, 2.37884, 0, 1.43134, -2.37884, 0, -1.43134, -3.52795, 0, 3.21547),
+"tilts": PackedFloat32Array(0, 0, 0, 0, 0)
+}
+point_count = 5
+
+[sub_resource type="HNPopulate" id="HNPopulate_hjt3c"]
+GroupName = "Triggers"
+Scene = ExtResource("1_3e6xf")
+
+[sub_resource type="HNCombineXYZ" id="HNCombineXYZ_2kukf"]
+
+[sub_resource type="HNInputValue" id="HNInputValue_go3x2"]
+
+[sub_resource type="HNInputValue" id="HNInputValue_ku0rx"]
+float_value = 2.0
+
+[sub_resource type="HNInputCurve3D" id="HNInputCurve3D_jgoeo"]
+
+[sub_resource type="HNCurveToPoints" id="HNCurveToPoints_xmpap"]
+
+[sub_resource type="HNAlignEulerToVector" id="HNAlignEulerToVector_lqpl1"]
+
+[sub_resource type="HNInputValue" id="HNInputValue_0m1yd"]
+
+[sub_resource type="HoodieMesh" id="HoodieMesh_0k4b1"]
+graph_offset = Vector2(-112.406, 7.42224)
+nodes/2/node = SubResource("HNInputCurve3D_jgoeo")
+nodes/2/position = Vector2(-60, 220)
+nodes/3/node = SubResource("HNCurveToPoints_xmpap")
+nodes/3/position = Vector2(240, 220)
+nodes/8/node = SubResource("HNAlignEulerToVector_lqpl1")
+nodes/8/position = Vector2(480, 300)
+nodes/9/node = SubResource("HNInputValue_0m1yd")
+nodes/9/position = Vector2(240, 480)
+nodes/10/node = SubResource("HNPopulate_hjt3c")
+nodes/10/position = Vector2(1180, 300)
+nodes/11/node = SubResource("HNCombineXYZ_2kukf")
+nodes/11/position = Vector2(940, 380)
+nodes/12/node = SubResource("HNInputValue_go3x2")
+nodes/12/position = Vector2(700, 380)
+nodes/13/node = SubResource("HNInputValue_ku0rx")
+nodes/13/position = Vector2(700, 480)
+nodes/connections = Array[int]([2, 0, 3, 0, 9, 0, 8, 1, 3, 1, 8, 2, 3, 0, 10, 0, 8, 0, 10, 1, 12, 0, 11, 0, 12, 0, 11, 1, 11, 0, 10, 2, 13, 0, 11, 2])
+"inputs/[2] Input Curve 3D [0] Curve3D" = SubResource("Curve3D_us8u6")
+"inputs/[10] Populate [1] " = ExtResource("1_3e6xf")
+
+[node name="SpawnNodes" type="Node3D"]
+
+[node name="Path3D" type="Path3D" parent="."]
+curve = SubResource("Curve3D_us8u6")
+
+[node name="Hoodie_Spawn" type="MeshInstance3D" parent="."]
+mesh = SubResource("HoodieMesh_0k4b1")
+
+[node name="Triggers" type="Node3D" parent="."]
+
+[node name="0" type="Node3D" parent="Triggers" instance=ExtResource("1_3e6xf")]
+transform = Transform3D(0.281088, 0, 1.91936, 0, 1, 0, -0.959682, 0, 0.562177, -5.28184, 0, 0.604791)
+
+[node name="1" type="Node3D" parent="Triggers" instance=ExtResource("1_3e6xf")]
+transform = Transform3D(0.366482, 0, 1.86085, 0, 1, 0, -0.930425, 0, 0.732965, -4.77265, 0, -1.13367)
+
+[node name="2" type="Node3D" parent="Triggers" instance=ExtResource("1_3e6xf")]
+transform = Transform3D(0.578012, 0, 1.63206, 0, 1, 0, -0.816028, 0, 1.15602, -4.08864, 0, -2.87024)
+
+[node name="3" type="Node3D" parent="Triggers" instance=ExtResource("1_3e6xf")]
+transform = Transform3D(0.917946, 0, 0.793413, 0, 1, 0, -0.396706, 0, 1.83589, -3.13436, 0, -4.21747)
+
+[node name="4" type="Node3D" parent="Triggers" instance=ExtResource("1_3e6xf")]
+transform = Transform3D(0.991362, 0, -0.262302, 0, 1, 0, 0.131151, 0, 1.98272, -1.81437, 0, -4.78793)
+
+[node name="5" type="Node3D" parent="Triggers" instance=ExtResource("1_3e6xf")]
+transform = Transform3D(0.911616, 0, -0.822086, 0, 1, 0, 0.411043, 0, 1.82323, -0.300031, 0, -4.58759)
+
+[node name="6" type="Node3D" parent="Triggers" instance=ExtResource("1_3e6xf")]
+transform = Transform3D(0.778052, 0, -1.2564, 0, 1, 0, 0.6282, 0, 1.5561, 1.09996, 0, -3.95634)
+
+[node name="7" type="Node3D" parent="Triggers" instance=ExtResource("1_3e6xf")]
+transform = Transform3D(0.588702, 0, -1.6167, 0, 1, 0, 0.80835, 0, 1.1774, 2.27505, 0, -3.00758)
+
+[node name="8" type="Node3D" parent="Triggers" instance=ExtResource("1_3e6xf")]
+transform = Transform3D(0.39011, 0, -1.84154, 0, 1, 0, 0.920768, 0, 0.78022, 3.11467, 0, -1.85469)
+
+[node name="9" type="Node3D" parent="Triggers" instance=ExtResource("1_3e6xf")]
+transform = Transform3D(0.241683, 0, -1.94071, 0, 1, 0, 0.970355, 0, 0.483366, 3.66418, 0, -0.557696)
+
+[node name="10" type="Node3D" parent="Triggers" instance=ExtResource("1_3e6xf")]
+transform = Transform3D(0.0684171, 0, -1.99531, 0, 1, 0, 0.997657, 0, 0.136834, 4.01052, 0, 0.83285)
+
+[node name="11" type="Node3D" parent="Triggers" instance=ExtResource("1_3e6xf")]
+transform = Transform3D(-0.157834, 0, -1.97493, 0, 1, 0, 0.987466, 0, -0.315667, 4.10549, 0, 2.21773)
+
+[node name="12" type="Node3D" parent="Triggers" instance=ExtResource("1_3e6xf")]
+transform = Transform3D(-0.780358, 0, -1.25066, 0, 1, 0, 0.625332, 0, -1.56072, 3.9009, 0, 3.49771)
+
+[node name="13" type="Node3D" parent="Triggers" instance=ExtResource("1_3e6xf")]
+transform = Transform3D(-0.996572, 0, -0.165469, 0, 1, 0, 0.0827347, 0, -1.99314, 2.8663, 0, 4.32678)
+
+[node name="14" type="Node3D" parent="Triggers" instance=ExtResource("1_3e6xf")]
+transform = Transform3D(-0.993059, 0, 0.235234, 0, 1, 0, -0.117617, 0, -1.98612, 0.893322, 0, 4.49057)
+
+[node name="15" type="Node3D" parent="Triggers" instance=ExtResource("1_3e6xf")]
+transform = Transform3D(-0.975091, 0, 0.443614, 0, 1, 0, -0.221807, 0, -1.95018, -0.262258, 0, 4.35371)
+
+[node name="16" type="Node3D" parent="Triggers" instance=ExtResource("1_3e6xf")]
+transform = Transform3D(-0.945442, 0, 0.651581, 0, 1, 0, -0.325791, 0, -1.89088, -1.43308, 0, 4.08738)
+
+[node name="17" type="Node3D" parent="Triggers" instance=ExtResource("1_3e6xf")]
+transform = Transform3D(-0.895362, 0, 0.890679, 0, 1, 0, -0.44534, 0, -1.79072, -2.54601, 0, 3.70387)
+
+[node name="18" type="Node3D" parent="Triggers" instance=ExtResource("1_3e6xf")]
+transform = Transform3D(0.895362, 0, -0.890679, 0, 1, 0, 0.44534, 0, 1.79072, -3.52795, 0, 3.21547)

--- a/src/hoodie_mesh.cpp
+++ b/src/hoodie_mesh.cpp
@@ -3,6 +3,8 @@
 #include <godot_cpp/variant/utility_functions.hpp>
 #include <godot_cpp/templates/vector.hpp>
 #include <godot_cpp/classes/material.hpp>
+#include <godot_cpp/classes/engine.hpp>
+#include <godot_cpp/classes/scene_tree.hpp>
 
 using namespace godot;
 

--- a/src/hoodie_nodes/output/hn_populate.cpp
+++ b/src/hoodie_nodes/output/hn_populate.cpp
@@ -1,0 +1,202 @@
+#include "hn_populate.h"
+
+#include <godot_cpp/classes/editor_interface.hpp>
+#include <godot_cpp/classes/node.hpp>
+#include <godot_cpp/classes/node3d.hpp>
+#include "utils/geo_utils.h"
+
+using namespace godot;
+
+void HNPopulate::set_group_name(const String p_value) {
+    group_name = p_value;
+}
+
+String HNPopulate::get_group_name() const {
+    return group_name;
+}
+
+void HNPopulate::set_resource(const Ref<PackedScene> p_value) {
+    scene = p_value;
+}
+
+Ref<PackedScene> HNPopulate::get_resource() const {
+    return scene;
+}
+
+void HNPopulate::_bind_methods() {
+    ClassDB::bind_method(D_METHOD("set_group_name", "value"), &HNPopulate::set_group_name);
+    ClassDB::bind_method(D_METHOD("get_group_name"), &HNPopulate::get_group_name);
+    ClassDB::bind_method(D_METHOD("set_resource", "value"), &HNPopulate::set_resource);
+    ClassDB::bind_method(D_METHOD("get_resource"), &HNPopulate::get_resource);
+
+    ADD_PROPERTY(PropertyInfo(Variant::STRING, "GroupName", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_group_name", "get_group_name");
+    ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "Scene", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_resource", "get_resource");
+}
+
+void HNPopulate::_process(const Array &p_inputs) {
+    Node* scene_root = EditorInterface::get_singleton()->get_edited_scene_root();
+
+    if (scene.is_null()) { return; }
+    if (group_name.is_empty()) { return; }
+
+    TypedArray<Node> children = scene_root->get_children();
+
+    Node3D *group_node = nullptr;
+    for (int i = 0; i < children.size(); i++) {
+        Node3D *child = Object::cast_to<Node3D>(children[i]);
+        if (child->get_name() == group_name) {
+            group_node = child;
+            break;
+        }
+    }
+
+    if (group_node == nullptr) {
+        group_node = memnew(Node3D);
+        group_node->set_name(group_name);
+        scene_root->add_child(group_node);
+        group_node->set_owner(scene_root);
+    }
+
+    // Clear group children.
+    TypedArray<Node> group_children = group_node->get_children();
+    for (int i = 0; i < group_children.size(); i++) {
+        Node3D *group_child = Object::cast_to<Node3D>(group_children[i]);
+        group_child->queue_free();
+    }
+
+    PackedVector3Array in_positions = p_inputs[0];
+    PackedVector3Array in_rotations = p_inputs[1];
+    PackedVector3Array in_scales = p_inputs[2];
+
+    const int count = Math::max(Math::max(in_positions.size(), in_rotations.size()), in_scales.size());
+
+    for (int i = 0; i < count; i++) {
+        Vector3 pos = Vector3(0, 0, 0);
+        Vector3 rot = Vector3(0, 0, 0);
+        Vector3 scale = Vector3(1, 1, 1);
+
+        if (in_positions.size() > i) {
+            pos = in_positions[i];
+        } else {
+            pos = in_positions[in_positions.size() - 1];
+        }
+
+        if (in_rotations.size() > i) {
+            rot = in_rotations[i];
+        } else {
+            rot = in_rotations[in_rotations.size() - 1];
+        }
+
+        if (in_scales.size() > i) {
+            scale = in_scales[i];
+        } else {
+            scale = in_scales[in_scales.size() - 1];
+        }
+
+        Node3D *instanced_scene = Object::cast_to<Node3D>(scene->instantiate());
+        instanced_scene->set_name(itos(i));
+        instanced_scene->set_position(pos);
+        instanced_scene->set_rotation(rot);
+        instanced_scene->set_scale(scale);
+
+        group_node->add_child(instanced_scene);
+        instanced_scene->set_owner(scene_root);
+    }
+}
+
+String HNPopulate::get_caption() const {
+    return "Populate";
+}
+
+int HNPopulate::get_input_port_count() const {
+    return 3;
+}
+
+HoodieNode::PortType HNPopulate::get_input_port_type(int p_port) const {
+    switch (p_port) {
+        case 0:
+            return PortType::PORT_TYPE_VECTOR_3D;
+        case 1:
+            return PortType::PORT_TYPE_VECTOR_3D;
+        case 2:
+            return PortType::PORT_TYPE_VECTOR_3D;
+        default:
+            return PortType::PORT_TYPE_SCALAR;
+    }
+}
+
+String HNPopulate::get_input_port_name(int p_port) const {
+    switch (p_port) {
+        case 0:
+            return "Positions";
+        case 1:
+            return "Rotations";
+        case 2:
+            return "Scales";
+        default:
+            return "";
+    }
+}
+
+int HNPopulate::get_output_port_count() const {
+    return 0;
+}
+
+HoodieNode::PortType HNPopulate::get_output_port_type(int p_port) const {
+    return PortType::PORT_TYPE_DATA;
+}
+
+String HNPopulate::get_output_port_name(int p_port) const {
+    return "Data";
+}
+
+int HNPopulate::get_property_input_count() const {
+    return 2;
+}
+
+Variant::Type HNPopulate::get_property_input_type(vec_size_t p_prop) const {
+    switch (p_prop) {
+        case 0:
+            return Variant::STRING;
+        case 1:
+            return Variant::OBJECT;
+        default:
+            return Variant::BOOL;
+    }
+}
+
+Variant HNPopulate::get_property_input(vec_size_t p_port) const {
+    switch (p_port) {
+        case 0:
+            return Variant(group_name);
+        case 1:
+            return Variant(scene);
+        default:
+            return Variant();
+    }
+}
+
+void HNPopulate::set_property_input(vec_size_t p_prop, Variant p_input) {
+    switch (p_prop)
+    {
+        case 0:
+            group_name = p_input;
+            break;
+        case 1:
+            scene = p_input;
+            break;
+        default:
+            break;
+    }
+}
+
+Vector<StringName> HNPopulate::get_editable_properties() const {
+    Vector<StringName> props;
+    props.push_back("GroupName");
+    props.push_back("Scene");
+    return props;
+}
+
+HashMap<StringName, String> HNPopulate::get_editable_properties_names() const {
+    return HashMap<StringName, String>();
+}

--- a/src/hoodie_nodes/output/hn_populate.h
+++ b/src/hoodie_nodes/output/hn_populate.h
@@ -1,0 +1,53 @@
+#ifndef HOODIE_HNPOPULATE_H
+#define HOODIE_HNPOPULATE_H
+
+#include "hoodie_node.h"
+
+#include <godot_cpp/classes/packed_scene.hpp>
+
+namespace godot
+{
+
+class HNPopulate : public HoodieNode {
+    GDCLASS(HNPopulate, HoodieNode)
+
+private:
+    // Input
+    String group_name;
+    Ref<PackedScene> scene;
+
+public:
+    void set_group_name(const String p_value);
+    String get_group_name() const;
+    void set_resource(const Ref<PackedScene> p_value);
+    Ref<PackedScene> get_resource() const;
+
+protected:
+    static void _bind_methods();
+
+public:
+    void _process(const Array &p_inputs) override;
+
+    String get_caption() const override;
+
+    int get_input_port_count() const override;
+	PortType get_input_port_type(int p_port) const override;
+	String get_input_port_name(int p_port) const override;
+
+    int get_output_port_count() const override;
+	PortType get_output_port_type(int p_port) const override;
+	String get_output_port_name(int p_port) const override;
+
+    int get_property_input_count() const override;
+    Variant::Type get_property_input_type(vec_size_t p_prop) const override;
+    Variant get_property_input(vec_size_t p_port) const override;
+    void set_property_input(vec_size_t p_prop, Variant p_input) override;
+
+    Vector<StringName> get_editable_properties() const override;
+    HashMap<StringName, String> get_editable_properties_names() const override;
+};
+    
+} // namespace godot
+
+
+#endif // HOODIE_HNPOPULATE_H

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -52,6 +52,7 @@
 #include "hoodie_nodes/utilities_rotation/hn_align_euler_to_vector.h"
 #include "hoodie_nodes/uv/hn_uv_math.h"
 #include "hoodie_nodes/output/hn_output.h"
+#include "hoodie_nodes/output/hn_populate.h"
 
 #include <gdextension_interface.h>
 #include <godot_cpp/core/defs.hpp>
@@ -109,6 +110,7 @@ void initialize_hoodie_module(ModuleInitializationLevel p_level) {
 		ClassDB::register_class<HNAlignEulerToVector>();
 		ClassDB::register_class<HNUVMath>();
 		ClassDB::register_class<HNOutput>();
+		ClassDB::register_class<HNPopulate>();
 
 		// Setup engine after classes are registered.
 		// This is necessary when using GDExtension because classes can't be instantiated until they are registered.


### PR DESCRIPTION
The populate node allows to spawn resource scenes (.tscn) in the working root scene.

To execute it the string property has to be changed: that will be the name of the parent node that will contain the spawned ones.

Providing an array of `Positions`, `Rotations`, and `Scales` the spawned nodes will be affected.