### PR TITLE
Add optional 'Process' button to nodes

### DIFF
--- a/src/hoodie_editor_plugin.cpp
+++ b/src/hoodie_editor_plugin.cpp
@@ -206,6 +206,17 @@ void HoodieGraphPlugin::add_node(id_t p_id, bool p_just_update) {
     }
     graph_node->add_child(props_vb);
 
+    // Add process button.
+    if (hoodie_node->has_button()) {
+        Button *button = memnew(Button);
+        button->set_custom_minimum_size(Size2(65, 0));
+        button->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+        button->set_text("Process");
+        button->connect("pressed", callable_mp(hoodie_node.ptr(), &HoodieNode::mark_dirty_button));
+        button->connect("pressed", callable_mp(hoodie_mesh.ptr(), &HoodieMesh::_queue_update));
+        graph_node->add_child(button);
+    }
+
     editor->hoodie_control->graph_edit->add_child(graph_node);
 }
 

--- a/src/hoodie_mesh.cpp
+++ b/src/hoodie_mesh.cpp
@@ -62,15 +62,10 @@ void HoodieMesh::_update() {
 
     // Iterate on all output nodes
     for (const KeyValue<id_t, Node> &E : graph.nodes) {
-        if (E.value.node->get_output_port_count() != 0) {
-            continue;
-        }
+        if (E.value.node->get_output_port_count() != 0) { continue; }
 
         bool changed = _update_node(E.key, E.value.node);
-
-        if (!changed) {
-            continue;
-        }
+        if (!changed) { continue; }
 
         Ref<Material> material;
 
@@ -87,10 +82,7 @@ void HoodieMesh::_update() {
         }
 
         Ref<HoodieArrayMesh> r_ham = E.value.node->get_output(0);
-
-        if (r_ham.is_null()) {
-            continue;
-        }
+        if (r_ham.is_null()) { continue; }
 
         Variant surface = r_ham->array;
 

--- a/src/hoodie_node.cpp
+++ b/src/hoodie_node.cpp
@@ -5,8 +5,15 @@
 using namespace godot;
 
 void HoodieNode::mark_dirty() {
-    dirty = true;
+    UtilityFunctions::print("Mark dirty!");
+    if (!has_button()) {
+        dirty = true;
+    }
     // TODO: emit_changed?
+}
+
+void HoodieNode::mark_dirty_button() {
+    dirty = true;
 }
 
 void HoodieNode::set_status(const ProcessStatus &p_status) {
@@ -23,7 +30,8 @@ void HoodieNode::_bind_methods() {
 }
 
 bool HoodieNode::update(bool p_inputs_updated, const Array &p_inputs) {
-    bool updated = dirty || p_inputs_updated;
+    bool inputs_button = has_button() ? false : p_inputs_updated;
+    bool updated = dirty || inputs_button;
     dirty = false;
 
     if (updated) {
@@ -92,6 +100,10 @@ Vector<StringName> HoodieNode::get_editable_properties() const {
 
 HashMap<StringName, String> HoodieNode::get_editable_properties_names() const {
     return HashMap<StringName, String>();
+}
+
+bool HoodieNode::has_button() const {
+    return false;
 }
 
 const Variant HoodieNode::get_output(int p_port) {

--- a/src/hoodie_node.h
+++ b/src/hoodie_node.h
@@ -61,6 +61,7 @@ private:
 
 protected:
     void mark_dirty();
+    void mark_dirty_button();
 
     // Store here the data outputs of the node.
     Array outputs;
@@ -99,6 +100,8 @@ public:
 
     virtual Vector<StringName> get_editable_properties() const;
     virtual HashMap<StringName, String> get_editable_properties_names() const;
+
+    virtual bool has_button() const;
 
     const Variant get_output(int p_port);
     void set_output(int p_port, const Variant &p_data);

--- a/src/hoodie_nodes/output/hn_populate.cpp
+++ b/src/hoodie_nodes/output/hn_populate.cpp
@@ -212,3 +212,7 @@ Vector<StringName> HNPopulate::get_editable_properties() const {
 HashMap<StringName, String> HNPopulate::get_editable_properties_names() const {
     return HashMap<StringName, String>();
 }
+
+bool HNPopulate::has_button() const {
+    return true;
+}

--- a/src/hoodie_nodes/output/hn_populate.h
+++ b/src/hoodie_nodes/output/hn_populate.h
@@ -45,6 +45,8 @@ public:
 
     Vector<StringName> get_editable_properties() const override;
     HashMap<StringName, String> get_editable_properties_names() const override;
+
+    bool has_button() const override;
 };
     
 } // namespace godot


### PR DESCRIPTION
Certain nodes may be not appropriate to update their outputs at every graph change (e.g. the `HNPopulate` node, since it spawns nodes at the root scene).

With this change, a node can have a 'Process' button that execute its update, and it will not be updated normally if changes are applied to input nodes.