### PR TITLE
Add HoodieGeo vector expression node

### DIFF
--- a/src/hoodie_datas/hoodie_geo.cpp
+++ b/src/hoodie_datas/hoodie_geo.cpp
@@ -31,8 +31,18 @@ Variant HoodieGeo::duplicate() {
     return ret;
 }
 
-TypedArray<PackedVector3Array> HoodieGeo::pack_primitive_points() const {
-    TypedArray<PackedVector3Array> ret;
+HashMap<String, Array> HoodieGeo::duplicate_attributes() const {
+    HashMap<String, Array> ret;
+
+    for (auto attr : attributes) {
+        ret[attr.key] = attr.value.duplicate();
+    }
+
+    return ret;
+}
+
+Vector<PackedVector3Array> HoodieGeo::pack_primitive_points() const {
+    Vector<PackedVector3Array> ret;
 
     for (Primitive p : primitives) {
         PackedVector3Array pts;
@@ -46,7 +56,7 @@ TypedArray<PackedVector3Array> HoodieGeo::pack_primitive_points() const {
     return ret;
 }
 
-void HoodieGeo::unpack_primitive_points(const TypedArray<PackedVector3Array> &p_array) {
+void HoodieGeo::unpack_primitive_points(const Vector<PackedVector3Array> &p_array) {
     points.clear();
     primitives.clear();
 
@@ -61,6 +71,42 @@ void HoodieGeo::unpack_primitive_points(const TypedArray<PackedVector3Array> &p_
             verts[p] = verts_counter++;
         }
         primitives.append(Primitive(verts));
+    }
+}
+
+Vector<HashMap<String, Array>> HoodieGeo::pack_primitive_attributes() const {
+    Vector<HashMap<String, Array>> ret;
+
+    for (Primitive p : primitives) {
+        HashMap<String, Array> map;
+
+        for (auto a : attributes) {
+            Array arr;
+            arr.resize(p.vertices.size());
+
+            for (int i = 0; i < p.vertices.size(); i++) {
+                arr[i] = map[a.key][p.vertices[i]];
+            }
+
+            map[a.key] = arr;
+        }
+
+        ret.push_back(map);
+    }
+    
+    return ret;
+}
+
+void HoodieGeo::unpack_primitive_attributes(const Vector<HashMap<String, Array>> &p_array) {
+    attributes.clear();
+
+    int verts_counter = 0;
+    for (int i = 0; i < p_array.size(); i++) {
+        HashMap<String, Array> attr_map = p_array[0];
+
+        for (auto attr : attr_map) {
+            attributes[attr.key].append_array(attr.value);
+        }
     }
 }
 

--- a/src/hoodie_datas/hoodie_geo.h
+++ b/src/hoodie_datas/hoodie_geo.h
@@ -38,14 +38,19 @@ public:
 
     Variant duplicate() override;
 
+    HashMap<String, Array> HoodieGeo::duplicate_attributes() const;
+
     HashMap<String, String> populate_tab_inspector() const override;
 
     static Ref<HoodieData> create_reference(const PackedVector3Array &p_points);
     static Ref<HoodieData> create_reference(const PackedVector3Array &p_points, const Vector<Primitive> &p_primitives);
     static Ref<HoodieData> create_reference(const PackedVector3Array &p_points, const PackedInt32Array &p_vertices);
 
-    TypedArray<PackedVector3Array> pack_primitive_points() const;
-    void unpack_primitive_points(const TypedArray<PackedVector3Array> &p_array);
+    Vector<PackedVector3Array> pack_primitive_points() const;
+    void unpack_primitive_points(const Vector<PackedVector3Array> &p_array);
+
+    Vector<HashMap<String, Array>> HoodieGeo::pack_primitive_attributes() const;
+    void unpack_primitive_attributes(const Vector<HashMap<String, Array>> &p_array);
 
     Array to_mesh() const;
 

--- a/src/hoodie_editor_plugin.cpp
+++ b/src/hoodie_editor_plugin.cpp
@@ -509,6 +509,7 @@ HoodieControl::HoodieControl() {
 
     add_options.push_back(AddOption("Add Attribute", "Utilities/Hoodie Geo", "HNAddAttribute"));
     add_options.push_back(AddOption("Compose Hoodie Geo", "Utilities/Hoodie Geo", "HNComposeHoodieGeo"));
+    add_options.push_back(AddOption("HGeo Vector Expr", "Utilities/Hoodie Geo", "HNHoodieGeoVectorExpression"));
     add_options.push_back(AddOption("HGeo To Mesh", "Utilities/Hoodie Geo", "HNHoodieGeoToMesh"));
     add_options.push_back(AddOption("Join HGeo", "Utilities/Hoodie Geo", "HNJoinHoodieGeo"));
 
@@ -1448,8 +1449,11 @@ void HoodieNodePluginDefaultEditor::_property_changed(const Variant &p_value, co
         undo_redo->add_do_method(p_property_control, "set_value_no_signal", p_value);
         undo_redo->add_undo_method(p_property_control, "set_value_no_signal", node->get(p_property));
     } else if (p_property_control->is_class("LineEdit")) {
+        LineEdit *le = Object::cast_to<LineEdit>(p_property_control);
         undo_redo->add_do_method(p_property_control, "set_text", p_value);
+        undo_redo->add_do_method(p_property_control, "set_caret_column", le->get_caret_column());
         undo_redo->add_undo_method(p_property_control, "set_text", node->get(p_property));
+        undo_redo->add_undo_method(p_property_control, "set_caret_column", le->get_caret_column());
     } else if (p_property_control->is_class("CheckButton")) {
         undo_redo->add_do_method(p_property_control, "set_pressed_no_signal", p_value);
         undo_redo->add_undo_method(p_property_control, "set_pressed_no_signal", node->get(p_property));

--- a/src/hoodie_nodes/curve_operations/hn_evenly_spaced_points_curve.cpp
+++ b/src/hoodie_nodes/curve_operations/hn_evenly_spaced_points_curve.cpp
@@ -17,8 +17,8 @@ void HNEvenlySpacedPointsCurve::_process(const Array &p_inputs) {
         }
     }
 
-    TypedArray<PackedVector3Array> packs = in_hgeo->pack_primitive_points();
-    TypedArray<PackedVector3Array> out_packs;
+    Vector<PackedVector3Array> packs = in_hgeo->pack_primitive_points();
+    Vector<PackedVector3Array> out_packs;
 
     for (int prim = 0; prim < packs.size(); prim++) {
         out_packs.push_back(GeoUtils::evenly_spaced_points_on_path(packs[prim], in_distance));

--- a/src/hoodie_nodes/curve_operations/hn_simplify_curve.cpp
+++ b/src/hoodie_nodes/curve_operations/hn_simplify_curve.cpp
@@ -68,17 +68,16 @@ void HNSimplifyCurve::_process(const Array &p_inputs) {
     Geometry2D g2d;
 
     // Pack points of the primitives
-    TypedArray<PackedVector3Array> points_group;
-    TypedArray<PackedVector3Array> new_points_group;
+    Vector<PackedVector3Array> points_group;
+    Vector<PackedVector3Array> new_points_group;
 
     // Pack points from primitives
     points_group = in_hgeo->pack_primitive_points();
-    new_points_group.resize(points_group.size());
 
     if (get_algorithm() == Douglas_Peucker) {
         // https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm
         for (int p = 0; p < points_group.size(); p++) {
-            new_points_group[p] = DouglasPeucker(points_group[p], in_epsilon);
+            new_points_group.push_back(DouglasPeucker(points_group[p], in_epsilon));
         }
     }
 

--- a/src/hoodie_nodes/curve_operations/hn_subdivision_curve.cpp
+++ b/src/hoodie_nodes/curve_operations/hn_subdivision_curve.cpp
@@ -31,8 +31,8 @@ void HNSubdivisionCurve::_process(const Array &p_inputs) {
     }
 
     // Pack points of the primitives
-    TypedArray<PackedVector3Array> points_group;
-    TypedArray<PackedVector3Array> new_points_group;
+    Vector<PackedVector3Array> points_group;
+    Vector<PackedVector3Array> new_points_group;
 
     // Pack points from primitives
     points_group = in_hgeo->pack_primitive_points();
@@ -67,7 +67,7 @@ void HNSubdivisionCurve::_process(const Array &p_inputs) {
             }
 
             // Set values for the next step.
-            points_group = new_points_group.duplicate(true);
+            points_group = new_points_group.duplicate();
         }
     }
 

--- a/src/hoodie_nodes/utilities_hgeo/hn_hoodie_geo_vector_expression.cpp
+++ b/src/hoodie_nodes/utilities_hgeo/hn_hoodie_geo_vector_expression.cpp
@@ -1,0 +1,295 @@
+#include "hn_hoodie_geo_vector_expression.h"
+
+#include <functional>
+#include <godot_cpp/classes/array_mesh.hpp>
+#include <godot_cpp/classes/expression.hpp>
+
+using namespace godot;
+
+void HNHoodieGeoVectorExpression::set_filter_expression(const String p_value) {
+    filter_expression = p_value;
+}
+
+String HNHoodieGeoVectorExpression::get_filter_expression() const {
+    return filter_expression;
+}
+
+void HNHoodieGeoVectorExpression::set_expression(const String p_value) {
+    expression = p_value;
+}
+
+String HNHoodieGeoVectorExpression::get_expression() const {
+    return expression;
+}
+
+void HNHoodieGeoVectorExpression::set_target(const Target p_value) {
+    target = p_value;
+}
+
+HNHoodieGeoVectorExpression::Target HNHoodieGeoVectorExpression::get_target() const {
+    return target;
+}
+
+void HNHoodieGeoVectorExpression::_bind_methods() {
+    ClassDB::bind_method(D_METHOD("set_filter_expression", "value"), &HNHoodieGeoVectorExpression::set_filter_expression);
+    ClassDB::bind_method(D_METHOD("get_filter_expression"), &HNHoodieGeoVectorExpression::get_filter_expression);
+    ClassDB::bind_method(D_METHOD("set_expression", "value"), &HNHoodieGeoVectorExpression::set_expression);
+    ClassDB::bind_method(D_METHOD("get_expression"), &HNHoodieGeoVectorExpression::get_expression);
+    ClassDB::bind_method(D_METHOD("set_target", "value"), &HNHoodieGeoVectorExpression::set_target);
+    ClassDB::bind_method(D_METHOD("get_target"), &HNHoodieGeoVectorExpression::get_target);
+
+    ADD_PROPERTY(PropertyInfo(Variant::STRING, "Filter", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_filter_expression", "get_filter_expression");
+    ADD_PROPERTY(PropertyInfo(Variant::STRING, "Expression", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_expression", "get_expression");
+    ADD_PROPERTY(PropertyInfo(Variant::INT, "Operation", PROPERTY_HINT_ENUM, "Points,PackedPoints", PROPERTY_USAGE_NO_EDITOR), "set_target", "get_target");
+
+    BIND_ENUM_CONSTANT(Target::Points);
+    BIND_ENUM_CONSTANT(Target::PackedPoints);
+}
+
+void HNHoodieGeoVectorExpression::_process(const Array &p_inputs) {
+    Ref<HoodieGeo> in_hgeo = p_inputs[0];
+    String attribute_name = "";
+
+    {
+        Array a = p_inputs[1];
+        if (a.size() > 0) {
+            attribute_name = a[0];
+        }
+    }
+
+    bool use_attribute = false;
+
+    UtilityFunctions::print("Attribute name: [" + attribute_name + "]");
+
+    if (in_hgeo.is_null()) { return; }
+    if (!attribute_name.is_empty()) {
+        use_attribute = true;
+        if (!in_hgeo->attributes.has(attribute_name)) { return; }
+    }
+
+    Ref<Expression> filter;
+    filter.instantiate();
+
+    PackedStringArray filter_params;
+    filter_params.push_back("i");
+    filter_params.push_back("ptscount");
+
+    Error f_error = filter->parse(filter_expression, filter_params);
+    if (f_error != Error::OK) {
+        UtilityFunctions::print("Filter parse NOT OK.");
+        return;
+    }
+
+    Vector<PackedVector3Array> pts_packs;
+    Vector<HashMap<String, Array>> attr_packs;
+
+    Vector<PackedVector3Array> out_pts_packs;
+    Vector<HashMap<String, Array>> out_attr_packs;
+
+    if (target == Target::Points) {
+        pts_packs.push_back(in_hgeo->points.duplicate());
+        attr_packs.push_back(in_hgeo->duplicate_attributes());
+    } else if (target == Target::PackedPoints) {
+        pts_packs = in_hgeo->pack_primitive_points();
+        attr_packs = in_hgeo->pack_primitive_attributes();
+    }
+
+    for (int prim = 0; prim < pts_packs.size(); prim++) {
+        PackedVector3Array pts = pts_packs[prim];
+        HashMap<String, Array> attributes = attr_packs[prim];
+
+        Array attr;
+        if (use_attribute) {
+            attr = attributes[attribute_name];
+
+            if (attr.size() < 1 || !Variant::can_convert(attr[0].get_type(), Variant::VECTOR3)) {
+                return;
+            }
+        }
+
+        PackedVector3Array target_arr = attribute_name.is_empty() ? pts : attr;
+
+        for (int i = 0; i < target_arr.size(); i++) {
+            Array filter_values;
+            filter_values.push_back(i);
+            filter_values.push_back(target_arr.size());
+
+            Variant filter_ret = filter->execute(filter_values);
+
+            if (filter->has_execute_failed()) {
+                UtilityFunctions::print("Filter execution failed.");
+                return;
+            }
+
+            Ref<Expression> expr;
+            expr.instantiate();
+
+            PackedStringArray expr_params;
+            expr_params.push_back("x");
+            expr_params.push_back("y");
+            expr_params.push_back("z");
+            if (use_attribute) { expr_params.push_back(attribute_name); }
+
+            Error expr_err = expr->parse(expression, expr_params);
+            if (expr_err != Error::OK) {
+                UtilityFunctions::print("Expr parse NOT OK.");
+                return;
+            }
+
+            if ((bool)filter_ret) {
+                Array expr_values;
+                expr_values.push_back(pts[i].x);
+                expr_values.push_back(pts[i].y);
+                expr_values.push_back(pts[i].z);
+                if (use_attribute) { expr_values.push_back(Vector3(attr[i])); }
+                if (use_attribute) { UtilityFunctions::print(attribute_name + " " + rtos(attr[0]) + " " + rtos(attr[1]) + " " + rtos(attr[2])); }
+
+                Variant expr_ret = expr->execute(expr_values);
+
+                if (filter->has_execute_failed()) {
+                    UtilityFunctions::print("Expression execution failed.");
+                    return;
+                }
+
+                // Return value validation
+                if (!Variant::can_convert(expr_ret.get_type(), Variant::Type::ARRAY)) { return; }
+                Array arr_ret = expr_ret;
+                if (arr_ret.size() != 3) { return; }
+                Variant x = arr_ret[0];
+                Variant y = arr_ret[1];
+                Variant z = arr_ret[2];
+                if (!Variant::can_convert(x.get_type(), Variant::FLOAT)) { return; }
+                if (!Variant::can_convert(y.get_type(), Variant::FLOAT)) { return; }
+                if (!Variant::can_convert(z.get_type(), Variant::FLOAT)) { return; }
+
+                target_arr[i] = Vector3(x, y, z);
+            }
+        }
+
+        if (use_attribute) {
+            attributes[attribute_name] = target_arr;
+            out_attr_packs.push_back(attributes);
+            out_pts_packs.push_back(pts);
+        } else {
+            out_pts_packs.push_back(target_arr);
+        }
+    }
+
+    Ref<HoodieGeo> out_hgeo = in_hgeo->duplicate();
+
+    if (target == Target::Points) {
+        if (use_attribute) {
+            out_hgeo->attributes[attribute_name] = out_attr_packs[0][attribute_name];
+        } else {
+            out_hgeo->points = out_pts_packs[0];
+        }
+    } else if (target == Target::PackedPoints) {
+        out_hgeo->unpack_primitive_points(out_pts_packs);
+        
+        if (use_attribute) {
+            out_hgeo->unpack_primitive_attributes(out_attr_packs);
+        }
+    }
+
+    set_output(0, out_hgeo);
+}
+
+String HNHoodieGeoVectorExpression::get_caption() const {
+    return "HGeo Vector Expr";
+}
+
+int HNHoodieGeoVectorExpression::get_input_port_count() const {
+    return 2;
+}
+
+HoodieNode::PortType HNHoodieGeoVectorExpression::get_input_port_type(int p_port) const {
+    switch (p_port) {
+        case 0:
+            return PortType::PORT_TYPE_HGEO;
+        case 1:
+            return PortType::PORT_TYPE_STRING;
+        default:
+            return PortType::PORT_TYPE_SCALAR;
+    }
+}
+
+String HNHoodieGeoVectorExpression::get_input_port_name(int p_port) const {
+    switch (p_port) {
+        case 0:
+            return "HGeo";
+        case 1:
+            return "Attribute";
+        default:
+            return "Data";
+    }
+}
+
+int HNHoodieGeoVectorExpression::get_output_port_count() const {
+    return 1;
+}
+
+HoodieNode::PortType HNHoodieGeoVectorExpression::get_output_port_type(int p_port) const {
+    return PortType::PORT_TYPE_HGEO;
+}
+
+String HNHoodieGeoVectorExpression::get_output_port_name(int p_port) const {
+    return "HGeo";
+}
+
+int HNHoodieGeoVectorExpression::get_property_input_count() const {
+    return 3;
+}
+
+Variant::Type HNHoodieGeoVectorExpression::get_property_input_type(vec_size_t p_prop) const {
+    switch (p_prop) {
+        case 0:
+            return Variant::STRING;
+        case 1:
+            return Variant::STRING;
+        case 2:
+            return Variant::INT;
+        default:
+            return Variant::INT;
+    }
+}
+
+Variant HNHoodieGeoVectorExpression::get_property_input(vec_size_t p_port) const {
+    switch (p_port) {
+        case 0:
+            return Variant(filter_expression);
+        case 1:
+            return Variant(expression);
+        case 2:
+            return Variant(target);
+        default:
+            return Variant();
+    }
+}
+
+void HNHoodieGeoVectorExpression::set_property_input(vec_size_t p_prop, Variant p_input) {
+    switch (p_prop) {
+        case 0:
+            filter_expression = (String)p_input;
+            break;
+        case 1:
+            expression = (String)p_input;
+            break;
+        case 2:
+            target = (Target)(int)p_input;
+            break;
+        default:
+            return;
+    }
+}
+
+Vector<StringName> HNHoodieGeoVectorExpression::get_editable_properties() const {
+    Vector<StringName> props;
+    props.push_back("Filter");
+    props.push_back("Expression");
+    props.push_back("Operation");
+    return props;
+}
+
+HashMap<StringName, String> HNHoodieGeoVectorExpression::get_editable_properties_names() const {
+    return HashMap<StringName, String>();
+}

--- a/src/hoodie_nodes/utilities_hgeo/hn_hoodie_geo_vector_expression.h
+++ b/src/hoodie_nodes/utilities_hgeo/hn_hoodie_geo_vector_expression.h
@@ -1,0 +1,61 @@
+#ifndef HOODIE_HNHGEOEXPRESSION_H
+#define HOODIE_HNHGEOEXPRESSION_H
+
+#include "hoodie_node.h"
+
+namespace godot
+{
+
+class HNHoodieGeoVectorExpression : public HoodieNode {
+    GDCLASS(HNHoodieGeoVectorExpression, HoodieNode)
+
+public:
+    enum Target {
+        Points,
+        PackedPoints,
+    };
+
+private:
+    // Input
+    String filter_expression = "";
+    String expression = "";
+    Target target = Points;
+
+public:
+    void set_filter_expression(const String p_value);
+    String get_filter_expression() const;
+    void set_expression(const String p_value);
+    String get_expression() const;
+    void set_target(const Target p_value);
+    Target get_target() const;
+
+protected:
+    static void _bind_methods();
+
+public:
+    void _process(const Array &p_inputs) override;
+
+    String get_caption() const override;
+
+    int get_input_port_count() const override;
+	PortType get_input_port_type(int p_port) const override;
+	String get_input_port_name(int p_port) const override;
+
+    int get_output_port_count() const override;
+	PortType get_output_port_type(int p_port) const override;
+	String get_output_port_name(int p_port) const override;
+
+    int get_property_input_count() const override;
+    Variant::Type get_property_input_type(vec_size_t p_prop) const override;
+    Variant get_property_input(vec_size_t p_port) const override;
+    void set_property_input(vec_size_t p_prop, Variant p_input) override;
+
+    Vector<StringName> get_editable_properties() const override;
+    HashMap<StringName, String> get_editable_properties_names() const override;
+};
+
+} // namespace godot
+
+VARIANT_ENUM_CAST(HNHoodieGeoVectorExpression::Target);
+
+#endif // HOODIE_HNHGEOEXPRESSION_H

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -35,6 +35,7 @@
 #include "hoodie_nodes/utilities_data/hn_shift_data.h"
 #include "hoodie_nodes/utilities_hgeo/hn_add_attribute.h"
 #include "hoodie_nodes/utilities_hgeo/hn_compose_hoodie_geo.h"
+#include "hoodie_nodes/utilities_hgeo/hn_hoodie_geo_vector_expression.h"
 #include "hoodie_nodes/utilities_hgeo/hn_hoodie_geo_to_mesh.h"
 #include "hoodie_nodes/utilities_hgeo/hn_join_hoodie_geo.h"
 #include "hoodie_nodes/utilities_math/hn_math_derivative.h"
@@ -96,6 +97,7 @@ void initialize_hoodie_module(ModuleInitializationLevel p_level) {
 		ClassDB::register_class<HNShiftData>();
 		ClassDB::register_class<HNAddAttribute>();
 		ClassDB::register_class<HNComposeHoodieGeo>();
+		ClassDB::register_class<HNHoodieGeoVectorExpression>();
 		ClassDB::register_class<HNHoodieGeoToMesh>();
 		ClassDB::register_class<HNJoinHoodieGeo>();
 		ClassDB::register_class<HNMathDerivative>();


### PR DESCRIPTION
The first property is a filter, where a `true` value applies the changes expressed in the next property expression.

You need to return an `Array` of size 3.

E.g.
Filter: `i == 0 || i == ptscount - 1`
Expression `[x + 1, y + 1, z + 1]`

The 'Attribute' input accepts a string, that is the name of an attribute of the `HoodieGeo`.
You can access later its values as a `Vector3`.

E.g.
Attribute: `N`
Filter: `i == 0 || i == ptscount - 1`
Expression `[-N.x, -N.y, -N.z]`

Also fixed a bug with `LineEdit` undo redo.