### PR TITLE
Add github actions to build a matrix of godot releases and OSs

### DIFF
--- a/.github/workflows/scons-cpp.yml
+++ b/.github/workflows/scons-cpp.yml
@@ -2,7 +2,7 @@ name: C++ SCons
 
 on:
   push:
-    branches: [ "master", "actions" ]
+    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
 

--- a/.github/workflows/scons-cpp.yml
+++ b/.github/workflows/scons-cpp.yml
@@ -29,8 +29,6 @@ jobs:
       run: pip install Scons
     - name: build
       run: scons target=editor dev_mode=yes dev_build=yes
-    - name: bundle build
-      run: tar cjf demo.tar.bz2
     - uses: actions/upload-artifact@v4
       with:
         name: hoodie-${{matrix.os}}-${{ matrix.version }}

--- a/.github/workflows/scons-cpp.yml
+++ b/.github/workflows/scons-cpp.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: submodules-init
-      uses: git submodules update --init
+      run: git submodules update --init
     - name: godot version
       run: cd godot-cpp && git checkout ${{ matrix.version }}
     - name: Setup Python

--- a/.github/workflows/scons-cpp.yml
+++ b/.github/workflows/scons-cpp.yml
@@ -10,13 +10,15 @@ jobs:
   build:
     strategy:
       matrix:
-
         os: [ubuntu-latest, windows-latest, macos-latest]
+        version: ["godot-4.2-stable", "godot-4.3-stable"]
     runs-on: ${{ matrix.os }}    
     steps:
     - uses: actions/checkout@v4
     - name: submodules-init
-      uses: snickerbockers/submodules-init@v4
+      uses: git submodules update --init
+    - name: godot version
+      run: cd godot-cpp && git checkout ${{ matrix.version }}
     - name: Setup Python
       uses: actions/setup-python@v5.2.0
       with:

--- a/.github/workflows/scons-cpp.yml
+++ b/.github/workflows/scons-cpp.yml
@@ -24,6 +24,7 @@ jobs:
       uses: actions/setup-python@v5.2.0
       with:
         cache: pip
+        python-version: '3.12'
     - name: setup scons
       run: pip install Scons
     - name: build

--- a/.github/workflows/scons-cpp.yml
+++ b/.github/workflows/scons-cpp.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: submodules-init
-      run: git submodules update --init
+      run: git submodule update --init
     - name: godot version
       run: cd godot-cpp && git checkout ${{ matrix.version }}
     - name: Setup Python

--- a/.github/workflows/scons-cpp.yml
+++ b/.github/workflows/scons-cpp.yml
@@ -2,7 +2,7 @@ name: C++ SCons
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "actions" ]
   pull_request:
     branches: [ "master" ]
 

--- a/.github/workflows/scons-cpp.yml
+++ b/.github/workflows/scons-cpp.yml
@@ -28,3 +28,9 @@ jobs:
       run: pip install Scons
     - name: build
       run: scons target=editor dev_mode=yes dev_build=yes
+    - name: bundle build
+      run: tar cjf demo.tar.bz2
+    - uses: actions/upload-artifact@v4
+      with:
+        name: hoodie-${{matrix.os}}-${{ matrix.version }}
+        path: demo

--- a/.github/workflows/scons-cpp.yml
+++ b/.github/workflows/scons-cpp.yml
@@ -1,0 +1,27 @@
+name: C++ SCons
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}    
+    steps:
+    - uses: actions/checkout@v4
+    - name: submodules-init
+      uses: snickerbockers/submodules-init@v4
+    - name: Setup Python
+      uses: actions/setup-python@v5.2.0
+      with:
+        cache: pip
+    - name: setup scons
+      run: pip install Scons
+    - name: build
+      run: scons target=editor dev_mode=yes dev_build=yes

--- a/.github/workflows/scons-cpp.yml
+++ b/.github/workflows/scons-cpp.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         version: ["godot-4.2-stable", "godot-4.3-stable"]

--- a/.github/workflows/scons-cpp.yml
+++ b/.github/workflows/scons-cpp.yml
@@ -24,7 +24,6 @@ jobs:
       uses: actions/setup-python@v5.2.0
       with:
         cache: pip
-        python-version: '3.12'
     - name: setup scons
       run: pip install Scons
     - name: build

--- a/src/hoodie_datas/hoodie_geo.h
+++ b/src/hoodie_datas/hoodie_geo.h
@@ -38,7 +38,7 @@ public:
 
     Variant duplicate() override;
 
-    HashMap<String, Array> HoodieGeo::duplicate_attributes() const;
+    HashMap<String, Array> duplicate_attributes() const;
 
     HashMap<String, String> populate_tab_inspector() const override;
 
@@ -49,7 +49,7 @@ public:
     Vector<PackedVector3Array> pack_primitive_points() const;
     void unpack_primitive_points(const Vector<PackedVector3Array> &p_array);
 
-    Vector<HashMap<String, Array>> HoodieGeo::pack_primitive_attributes() const;
+    Vector<HashMap<String, Array>> pack_primitive_attributes() const;
     void unpack_primitive_attributes(const Vector<HashMap<String, Array>> &p_array);
 
     Array to_mesh() const;


### PR DESCRIPTION
Add build and archive for godot 4.2, 4.3, linux, mac and windows.

I don't know CPP well enough to debug the builds on the various version in any reasonable time, so I figured to get this out now, and someone else can look at the issues around the various environments.

Missing: 

 - a release pipeline to make it easy to release new versions.  Need input on how this should be done.